### PR TITLE
Compiler name / location 

### DIFF
--- a/PlayScript.Addin/MonoDevelop.PlayScript/ActionScriptScriptLanguageBinding.cs
+++ b/PlayScript.Addin/MonoDevelop.PlayScript/ActionScriptScriptLanguageBinding.cs
@@ -47,7 +47,7 @@ namespace MonoDevelop.PlayScript
 		
 		public BuildResult Compile (ProjectItemCollection projectItems, DotNetProjectConfiguration configuration, ConfigurationSelector configSelector, IProgressMonitor monitor)
 		{
-			return CSharpBindingCompilerManager.Compile (projectItems, configuration, configSelector, monitor);
+			return PlayScriptBindingCompilerManager.Compile (projectItems, configuration, configSelector, monitor);
 		}
 		
 		public ConfigurationParameters CreateCompilationParameters (XmlElement projectOptions)

--- a/PlayScript.Addin/MonoDevelop.PlayScript/PlayScriptLanguageBinding.cs
+++ b/PlayScript.Addin/MonoDevelop.PlayScript/PlayScriptLanguageBinding.cs
@@ -47,7 +47,7 @@ namespace MonoDevelop.PlayScript
 		
 		public BuildResult Compile (ProjectItemCollection projectItems, DotNetProjectConfiguration configuration, ConfigurationSelector configSelector, IProgressMonitor monitor)
 		{
-			return CSharpBindingCompilerManager.Compile (projectItems, configuration, configSelector, monitor);
+			return PlayScriptBindingCompilerManager.Compile (projectItems, configuration, configSelector, monitor);
 		}
 		
 		public ConfigurationParameters CreateCompilationParameters (XmlElement projectOptions)

--- a/PlayScript.Addin/PlayScript.Addin.csproj
+++ b/PlayScript.Addin/PlayScript.Addin.csproj
@@ -124,7 +124,6 @@
     <Compile Include="PlayScript.AddinReference.cs" />
     <Compile Include="PlayScript.AddinReferenceCollection.cs" />
     <Compile Include="Properties\PlayScript.AddinInfo.cs" />
-    <Compile Include="MonoDevelop.PlayScript\CSharpBindingCompilerManager.cs" />
     <Compile Include="MonoDevelop.PlayScript\CSharpEnhancedCodeProvider.cs" />
     <Compile Include="MonoDevelop.PlayScript\ExpandSelectionHandler.cs" />
     <Compile Include="MonoDevelop.PlayScript\CSharpAmbience.cs" />
@@ -210,6 +209,7 @@
     <Compile Include="MonoDevelop.PlayScript.Resolver\TextEditorResolverProvider.cs" />
     <Compile Include="MonoDevelop.PlayScript.Resolver\HelperMethods.cs" />
     <Compile Include="MonoDevelop.PlayScript.Tooltips\LanguageItemTooltipProvider.cs" />
+    <Compile Include="MonoDevelop.PlayScript\PlayScriptBindingCompilerManager.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="icons\actionscript-file-source-32%402x.psd" />
@@ -400,6 +400,9 @@
     <AddinFile Include="..\..\playscript\mcs\class\lib\net_4_5\pscorlib_aot.dll.mdb">
       <Link>MonoDevelop.PlayScript.SupportPackages\pscorlib_aot.dll.mdb</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </AddinFile>
+    <AddinFile Include="..\..\playscript\mcs\psc\psc">
+      <Link>MonoDevelop.PlayScript.SupportPackages\psc</Link>
     </AddinFile>
   </ItemGroup>
   <ItemGroup>

--- a/PlayScript.Addin/Properties/PlayScript.AddinInfo.cs
+++ b/PlayScript.Addin/Properties/PlayScript.AddinInfo.cs
@@ -15,4 +15,12 @@ using Mono.Addins.Description;
 [assembly:AddinDescription ("PlayScript and ActionScript Support for Xamarin Studio\n\nBy SushiHangover")]
 [assembly:AddinAuthor ("SushiHangover/RobertN")]
 
-
+[assembly:Mono.Addins.ImportAddinAssembly ("ICSharpCode.Decompiler.dll")]
+[assembly:Mono.Addins.ImportAddinAssembly ("ICSharpCode.NRefactory.PlayScript.IKVM.dll")]
+[assembly:Mono.Addins.ImportAddinAssembly ("ICSharpCode.NRefactory.PlayScript.Refactoring.dll")]
+[assembly:Mono.Addins.ImportAddinAssembly ("ICSharpCode.NRefactory.PlayScript.Xml.dll")]
+[assembly:Mono.Addins.ImportAddinAssembly ("ICSharpCode.NRefactory.PlayScript.dll")]
+[assembly:Mono.Addins.ImportAddinAssembly ("IKVM.Reflection.dll")]
+[assembly:Mono.Addins.ImportAddinAssembly ("Mono.Cecil.Mdb.dll")]
+[assembly:Mono.Addins.ImportAddinAssembly ("Mono.Cecil.Pdb.dll")]
+[assembly:Mono.Addins.ImportAddinAssembly ("Mono.Cecil.dll")]


### PR DESCRIPTION
Name/Location of compiler:
- psc (if not Windows)
- psc.exe (if Windows)

1st) Alternative Framework / Runtime tool location
2nd) Addin directory (within the "MonoDevelop.PlayScript.SupportPackages" subdir
